### PR TITLE
解决流程定义时，用户类型由候选角色切换到指定用户时，导致xml生成错误

### DIFF
--- a/ruoyi-ui/src/components/Process/components/nodePanel/task.vue
+++ b/ruoyi-ui/src/components/Process/components/nodePanel/task.vue
@@ -358,6 +358,10 @@ export default {
   },
   watch: {
     'formData.userType': function(val, oldVal) {
+      //判断切换用户类型时，不是候选角色类型的 删除该属性
+      if(val !== 'candidateGroups'){
+         delete this.element.businessObject.candidateGroups;
+      }
       if (StrUtil.isNotBlank(oldVal)) {
           delete this.element.businessObject.$attrs[`flowable:${oldVal}`]
           delete this.formData[oldVal]


### PR DESCRIPTION
解决流程定义时，用户类型由候选角色切换到指定用户时，导致xml生成错误，进而导致流程实例化完成后，一个节点提交到下一节点，后端报错找不到${approval}属性问题